### PR TITLE
Fix broken links in spaces-overview

### DIFF
--- a/docs/hub/spaces-overview.md
+++ b/docs/hub/spaces-overview.md
@@ -79,8 +79,8 @@ If you want to duplicate a Space, you can click the three dots at the top right 
 * Owner: The duplicated Space can be under your account or any organization in which you have write access
 * Space name
 * Visiblity: The Space is private by default. Read more about private repositories [here](./repositories-settings#private-repositories). 
-* Hardware: You can choose the hardware on which the Space will be running. Read more about hardware upgrades [here](./spaces-gpus.md).
-* Storage: If the original repo uses persistent storage, you will be prompted to choose a storage tier. Read more about persistent storage [here](./spaces-storage.md).
+* Hardware: You can choose the hardware on which the Space will be running. Read more about hardware upgrades [here](./spaces-gpus).
+* Storage: If the original repo uses persistent storage, you will be prompted to choose a storage tier. Read more about persistent storage [here](./spaces-storage).
 * Secrets and variables: If the original repo has set some secrets and variables, you'll be able to set them while duplicating the repo.
 
 Some Spaces might have environment variables that you may need to set up. In these cases, the duplicate workflow will auto-populate the public Variables from the source Space, and give you a warning about setting up the Secrets. The duplicated Space will use a free CPU hardware by default, but you can later upgrade if needed.


### PR DESCRIPTION
Links to `Spaces GPU Upgrades` and `Spaces Persistence Storage` are broken and results in 404.